### PR TITLE
Improve syslog use

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,6 +59,10 @@ enduro_systemd_credentials: false
 enduro_config_file: "templates/enduro.toml.j2"
 preprocessing_config_file: "templates/preprocessing-worker.toml.j2"
 
+# Logging configuration
+enduro_use_syslog: false
+enduro_remote_syslog: "none"
+
 # Enduro pipelines
 enduro_pipelines: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ enduro_systemd_after_services: "network.target temporal.service"
 enduro_systemd_wantedby_services: "multi-user.target"
 enduro_temporal_namespace: "default" # By default only temporal-system namespace exists
 enduro_debug_verbosity: 2
-enduro_debug_enabled: "true"
+enduro_debug_enabled: "false"
 enduro_listen_temporal_address: "127.0.0.1:7233"
 enduro_api_debug_enabled: "false"
 enduro_create_pipeline_transfer_dir: "false"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -19,3 +19,11 @@
     daemon_reload: true
     name: preprocessing-worker
     state: restarted
+
+- name: restart rsyslog
+  become: true
+  systemd:
+    daemon_reload: true
+    name: rsyslog
+    state: restarted
+  when: enduro_use_syslog|bool

--- a/tasks/configure-enduro-am-worker.yml
+++ b/tasks/configure-enduro-am-worker.yml
@@ -10,3 +10,13 @@
     - templates/{{ inventory_hostname }}/enduro-am-worker.service.j2
     - templates/enduro-am-worker.service.j2
   notify: restart enduro-am-worker
+
+- name: Configure logging
+  block:
+    - include_tasks: configure-logging.yml
+      vars:
+        service: "enduro-am-worker"
+        logfile: "/var/log/enduro/enduro-am-worker.log"
+        order: "50"
+  when: enduro_use_syslog|bool
+

--- a/tasks/configure-enduro.yml
+++ b/tasks/configure-enduro.yml
@@ -71,3 +71,13 @@
   when:
     - enduro_pipelines|length > 0
     - enduro_create_pipeline_transfer_dir|bool
+
+- name: Configure logging
+  block:
+    - include_tasks: configure-logging.yml
+      vars:
+        service: "enduro"
+        logfile: "/var/log/enduro/enduro.log"
+        order: "50"
+  when: enduro_use_syslog|bool
+

--- a/tasks/configure-logging.yml
+++ b/tasks/configure-logging.yml
@@ -1,0 +1,19 @@
+- name: "Create logs folder"
+  become: yes
+  file:
+    path: "/var/log/enduro/"
+    owner: "{{ enduro_system_user }}"
+    group: "{{ enduro_system_group }}"
+    mode: 0755
+    state: "directory"
+
+- name: "Configure rsyslog"
+  template:
+    src: templates/rsyslog.conf.j2
+    dest: /etc/rsyslog.d/50-{{ service }}.conf
+  notify: restart rsyslog
+
+- name: "Configure log rotation"
+  template:
+    src: templates/logrotate.conf.j2
+    dest: /etc/logrotate.d/{{ service }}

--- a/tasks/configure-preprocessing-worker.yml
+++ b/tasks/configure-preprocessing-worker.yml
@@ -1,5 +1,3 @@
----
-
 - name: "Create preprocessing shared folder"
   become: yes
   file:
@@ -52,3 +50,14 @@
         path: "/etc/preprocessing-worker.toml"
         state: absent
   when: enduro_systemd_credentials|bool
+
+- name: Configure logging
+  block:
+    - include_tasks: configure-logging.yml
+      vars:
+        service: "preprocessing-worker"
+        logfile: "/var/log/enduro/preprocessing-worker.log"
+        order: "50"
+  when: enduro_use_syslog|bool
+
+  

--- a/templates/enduro-am-worker.service.j2
+++ b/templates/enduro-am-worker.service.j2
@@ -14,6 +14,11 @@ ExecStart=/usr/bin/enduro-am-worker --config $SECRETS
 {% else %}
 ExecStart=/usr/bin/enduro-am-worker --config /etc/enduro.toml
 {% endif %}
+{% if enduro_use_syslog|bool %}
+SyslogIdentifier=enduro-am-worker
+StandardOutput=syslog
+StandardError=inherit
+{% endif %}
 
 # Let systemd restart this service always
 #Restart=always

--- a/templates/enduro.service.j2
+++ b/templates/enduro.service.j2
@@ -6,12 +6,15 @@ After={{ enduro_systemd_after_services }}
 Type=simple
 Restart=on-failure
 User={{ enduro_system_user }}
-SyslogIdentifier=EnduroStdout
-SyslogFacility=local1
 {% if enduro_systemd_credentials|bool %}
 ExecStart={{ enduro_binary_install_dir }}/enduro --config $SECRETS
 {% else %}
 ExecStart={{ enduro_binary_install_dir }}/enduro --config /etc/enduro.toml
+{% endif %}
+{% if enduro_use_syslog|bool %}
+SyslogIdentifier=enduro
+StandardOutput=syslog
+StandardError=inherit
 {% endif %}
 
 [Install]

--- a/templates/logrotate.conf.j2
+++ b/templates/logrotate.conf.j2
@@ -1,0 +1,13 @@
+{{ logfile }}
+{
+        rotate 7
+        daily
+        missingok
+        notifempty
+        delaycompress
+        compress
+        postrotate
+          sudo systemctl reload rsyslog >/dev/null 2>&1 || true
+        endscript
+
+}

--- a/templates/preprocessing-worker.service.j2
+++ b/templates/preprocessing-worker.service.j2
@@ -13,7 +13,11 @@ ExecStart=/usr/bin/preprocessing-worker --config $SECRETS
 {% else %}
 ExecStart=/usr/bin/preprocessing-worker --config /etc/preprocessing-worker.toml
 {% endif %}
-
+{% if enduro_use_syslog|bool %}
+SyslogIdentifier=preprocessing-worker
+StandardOutput=syslog
+StandardError=inherit
+{% endif %}
 
 # Let systemd restart this service always
 #Restart=always

--- a/templates/preprocessing-worker.toml.j2
+++ b/templates/preprocessing-worker.toml.j2
@@ -1,7 +1,7 @@
 {% if enduro_pipelines|length > 0 %}
 {% set pipeline = enduro_pipelines[0] %}
 
-debug = true
+debug = false
 verbosity = 2
 sharedPath = "/var/lib/enduro/preprocessing"
 

--- a/templates/rsyslog.conf.j2
+++ b/templates/rsyslog.conf.j2
@@ -1,0 +1,13 @@
+if ($programname == "{{ service }}") then {
+        action(
+                type="omfile"
+                FileOwner="enduro"
+                FileGroup="enduro"
+                File="{{ logfile }}"
+                FileCreateMode="0644"
+        )
+	{% if enduro_remote_syslog != "none" %}
+	*.*      @@{{ enduro_remote_syslog }}
+        {% endif %}
+        stop
+}


### PR DESCRIPTION
  
It uses two vars, boolean `enduro_use_syslog` for enabling, and     `enduro_remote_syslog: "<syslog_server:port>" ` for forwarding logs to a remote syslog server
