### PR TITLE
Upload to internal bucket

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,6 +62,9 @@ preprocessing_db_port: "3306"
 preprocessing_check_duplicates: "true"
 preprocessing_verapdf_path: "/usr/local/verapdf/verapdf"
 
+# Other Enduro settings
+enduro_upload_max_size: 4294967296 # 4 GiB
+
 # Systemd credentials are disabled by default
 enduro_systemd_credentials: false
 

--- a/templates/enduro.toml.j2
+++ b/templates/enduro.toml.j2
@@ -112,13 +112,13 @@ bucket = "failed-sips"
 [upload]
 maxSize = {{ enduro_upload_max_size }}
 
-[upload.bucket]
+[internalBucket]
 endpoint = "{{ pipeline.watched_endpoint }}"
-pathStyle = "{{ pipeline.watched_pathStyle }}"
+pathStyle = true
 accessKey = "{{ pipeline.watched_key }}"
 secretKey = "{{ pipeline.watched_secret }}"
 region = "{{ pipeline.watched_region }}"
-bucket = "{{ pipeline.watched_bucket }}"
+bucket = "enduro-ingest"
 
 [watcher.embedded]
 name = "{{ pipeline.watched_name }}"

--- a/templates/enduro.toml.j2
+++ b/templates/enduro.toml.j2
@@ -110,7 +110,7 @@ region = "{{ pipeline.watched_region }}"
 bucket = "failed-sips"
 
 [upload]
-maxSize = 102400000
+maxSize = {{ enduro_upload_max_size }}
 
 [upload.bucket]
 endpoint = "{{ pipeline.watched_endpoint }}"


### PR DESCRIPTION
- Allow enduro_upload_max_size configuration
- Rename upload.bucket to internalBucket:
  Follow the same approach as with the failed buckets configuration,
  hardcoded pathStyle and bucket name.

I'll follow-up with a MR in the playbooks where the `enduro-ingest` bucket will be created in MinIO.

Related to https://github.com/artefactual-sdps/enduro/issues/1210.