### PR TITLE
Avoid reserved logging include variable

### DIFF
--- a/tasks/configure-enduro-am-worker.yml
+++ b/tasks/configure-enduro-am-worker.yml
@@ -18,5 +18,5 @@
         service: "enduro-am-worker"
         conf_files_name: "enduro-am-worker"
         logfile: "/var/log/enduro/enduro-am-worker.log"
-        order: "50"
+        rsyslog_order: "50"
   when: enduro_use_syslog|bool

--- a/tasks/configure-enduro.yml
+++ b/tasks/configure-enduro.yml
@@ -93,7 +93,7 @@
         service: "enduro"
         conf_files_name: "enduro"
         logfile: "/var/log/enduro/enduro.log"
-        order: "50"
+        rsyslog_order: "50"
   when: enduro_use_syslog|bool
 
 - name: Configure audit logging
@@ -103,7 +103,7 @@
         service: "enduro"
         conf_files_name: "enduro-audit"
         logfile: "{{ enduro_auditlog_filepath }}"
-        order: "51"
+        rsyslog_order: "51"
   when: 
     - enduro_use_syslog|bool
     - enduro_auditlog_filepath | length > 0

--- a/tasks/configure-logging.yml
+++ b/tasks/configure-logging.yml
@@ -10,7 +10,7 @@
 - name: "Configure rsyslog"
   template:
     src: templates/rsyslog.conf.j2
-    dest: /etc/rsyslog.d/{{ order }}-{{ conf_files_name }}.conf
+    dest: /etc/rsyslog.d/{{ rsyslog_order }}-{{ conf_files_name }}.conf
   notify: restart rsyslog
 
 - name: "Configure log rotation"


### PR DESCRIPTION
Rename the logging include variable from order to rsyslog_order so Ansible no longer reports a reserved name warning during syntax checks.